### PR TITLE
pkgs: fail if bad relation is used

### DIFF
--- a/pkgs/jobs/jobs_test_jobs.go
+++ b/pkgs/jobs/jobs_test_jobs.go
@@ -224,6 +224,8 @@ func AssertJob(assertion *definitions.Assert, do *definitions.Do) (string, error
 		} else {
 			return assertFail("<=", assertion.Key, assertion.Value)
 		}
+	default:
+		return "", fmt.Errorf("Error: Bad assert relation: \"%s\" is not a valid relation. See documentation for more information.", assertion.Relation)
 	}
 
 	return result, nil

--- a/tests/jobs_fixtures/expected-failure-1135-bad-relation/epm.yaml
+++ b/tests/jobs_fixtures/expected-failure-1135-bad-relation/epm.yaml
@@ -1,0 +1,32 @@
+jobs:
+
+- name: MinersFee
+  job:
+    set:
+      val: 1234
+
+- name: to_save
+  job:
+    set:
+      val: 5000
+
+- name: nameRegTestDataFile1
+  job:
+    register:
+      data_file: names1.csv
+      amount: $to_save
+      fee: $MinersFee
+
+- name: queryReg1
+  job:
+    query-name:
+      name: burrow
+      field: data
+
+- name: nameRegAssert1
+  job:
+    assert:
+      key: $queryReg1
+# XXX this bad relation should fail
+      relation: neq
+      val: marmot_home

--- a/tests/jobs_fixtures/expected-failure-1135-bad-relation/names1.csv
+++ b/tests/jobs_fixtures/expected-failure-1135-bad-relation/names1.csv
@@ -1,0 +1,3 @@
+burrow,marmot_home
+screech,marmot_call
+marmots_are_not,rodents

--- a/tests/jobs_fixtures/expected-failure-1135-bad-relation/readme.md
+++ b/tests/jobs_fixtures/expected-failure-1135-bad-relation/readme.md
@@ -1,0 +1,2 @@
+* tests that the job run fails if a bad relation is used: see issue #1135
+* based on app02

--- a/tests/test_jobs.sh
+++ b/tests/test_jobs.sh
@@ -155,6 +155,25 @@ perform_tests(){
   done
 }
 
+perform_tests_that_should_fail(){
+  echo ""
+  goto_base
+  apps=(expected-failure*/)
+  for app in "${apps[@]}"
+  do
+    run_test $app
+
+    # Set exit code properly
+    test_exit=$?
+    if [ $test_exit -ne 0 ]
+    then
+      # actually, this test is meant to pass
+      test_exit=0
+      break
+    fi
+  done
+}
+
 test_teardown(){
   if [ -z "$ci" ]
   then
@@ -206,7 +225,10 @@ then
     echo "Running One Test..."
     run_test "$1*/"
   else
-    echo "Running All Tests..."
+    echo "Running tests that should fail"
+    perform_tests_that_should_fail
+
+    echo "Running tests that should pass"
     perform_tests
   fi
 fi


### PR DESCRIPTION
- adds a `default` to the `switch {}` for assert relations such that `monax pkgs do` will fail if an invalid relation is used. 
- implements a `expected-failure*` directory structure as part of the jobs_fixtures test sequence, so that we can test for, well, expected failures, such as the current fix. 
- closes #1135 